### PR TITLE
Make dict entries pairs; displayed and matched

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,51 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug executable 'typing-to-input'",
+            "cargo": {
+                "args": [
+                    "build",
+                    "--bin=typing-to-input",
+                    "--package=typing-to-input"
+                ],
+                "filter": {
+                    "name": "typing-to-input",
+                    "kind": "bin"
+                }
+            },
+            "args": [
+                "-c",
+                "gameboy.yml",
+                "-i",
+                "tui",
+                "Visual Studio Code"
+            ],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug unit tests in executable 'typing-to-input'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--bin=typing-to-input",
+                    "--package=typing-to-input"
+                ],
+                "filter": {
+                    "name": "typing-to-input",
+                    "kind": "bin"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        }
+    ]
+}

--- a/config1.yml
+++ b/config1.yml
@@ -21,269 +21,269 @@ layout: |2
 
 dictionaries:
   simple:
-  - was
-  - her
-  - said
-  - has
-  - well
-  - part
-  - world
-  - head
-  - put
-  - tell
-  - heart
-  - set
-  - told
-  - course
-  - words
-  - word
-  - whose
-  - half
-  - says
-  - held
-  - war
-  - kept
-  - hard
-  - hold
-  - sort
-  - cut
-  - pass
-  - horse
-  - red
-  - parts
-  - court
-  - top
-  - step
-  - per
-  - hot
-  - steps
-  - soft
-  - spot
-  - stop
-  - worse
-  - start
-  - hat
-  - heads
-  - spread
-  - hearts
-  - sad
-  - hurt
-  - tells
-  - wore
-  - stars
-  - rough
-  - car
-  - cup
-  - salt
-  - sell
-  - store
-  - wet
-  - hers
-  - cap
-  - press
-  - staff
-  - what's
-  - hell
-  - cat
-  - port
-  - sorts
-  - Scott
-  - star
-  - holds
-  - stuff
-  - pull
-  - card
-  - wrought
-  - web
-  - pour
-  - roll
-  - courts
-  - curse
-  - sore
-  - wept
-  - wars
-  - score
-  - roar
-  - hut
-  - sport
-  - spell
-  - ward
-  - sets
-  - purse
-  - pot
-  - cart
-  - corpse
-  - trap
-  - spots
-  - rob
-  - tread
-  - swell
-  - rod
-  - cars
-  - hats
-  - cab
-  - cups
-  - tops
-  - halt
-  - worlds
-  - pub
-  - tour
-  - wells
-  - ports
-  - cord
-  - sweat
-  - stress
-  - pet
-  - skull
-  - pulse
-  - cats
-  - rolls
-  - tough
-  - stead
-  - cuts
-  - harp
-  - rub
-  - spur
-  - pat
-  - sob
-  - pots
-  - Scots
-  - Carl
-  - sports
-  - calf
-  - stool
-  - pearl
-  - caps
-  - hull
-  - trod
-  - wed
-  - cough
-  - rats
-  - raft
-  - trot
-  - Ted
-  - rat
-  - tap
-  - carts
-  - cords
-  - core
-  - toss
-  - rug
-  - wad
-  - sub
-  - stroll
-  - rag
-  - puff
-  - rot
-  - peg
-  - tub
-  - sol
-  - sup
-  - hurts
-  - curl
-  - wrap
-  - cot
-  - sap
-  - scarf
-  - scar
+    was:
+    her:
+    said:
+    has:
+    well:
+    part:
+    world:
+    head:
+    put:
+    tell:
+    heart:
+    set:
+    told:
+    course:
+    words:
+    word:
+    whose:
+    half:
+    says:
+    held:
+    war:
+    kept:
+    hard:
+    hold:
+    sort:
+    cut:
+    pass:
+    horse:
+    red:
+    parts:
+    court:
+    top:
+    step:
+    per:
+    hot:
+    steps:
+    soft:
+    spot:
+    stop:
+    worse:
+    start:
+    hat:
+    heads:
+    spread:
+    hearts:
+    sad:
+    hurt:
+    tells:
+    wore:
+    stars:
+    rough:
+    car:
+    cup:
+    salt:
+    sell:
+    store:
+    wet:
+    hers:
+    cap:
+    press:
+    staff:
+    what's:
+    hell:
+    cat:
+    port:
+    sorts:
+    Scott:
+    star:
+    holds:
+    stuff:
+    pull:
+    card:
+    wrought:
+    web:
+    pour:
+    roll:
+    courts:
+    curse:
+    sore:
+    wept:
+    wars:
+    score:
+    roar:
+    hut:
+    sport:
+    spell:
+    ward:
+    sets:
+    purse:
+    pot:
+    cart:
+    corpse:
+    trap:
+    spots:
+    rob:
+    tread:
+    swell:
+    rod:
+    cars:
+    hats:
+    cab:
+    cups:
+    tops:
+    halt:
+    worlds:
+    pub:
+    tour:
+    wells:
+    ports:
+    cord:
+    sweat:
+    stress:
+    pet:
+    skull:
+    pulse:
+    cats:
+    rolls:
+    tough:
+    stead:
+    cuts:
+    harp:
+    rub:
+    spur:
+    pat:
+    sob:
+    pots:
+    Scots:
+    Carl:
+    sports:
+    calf:
+    stool:
+    pearl:
+    caps:
+    hull:
+    trod:
+    wed:
+    cough:
+    rats:
+    raft:
+    trot:
+    Ted:
+    rat:
+    tap:
+    carts:
+    cords:
+    core:
+    toss:
+    rug:
+    wad:
+    sub:
+    stroll:
+    rag:
+    puff:
+    rot:
+    peg:
+    tub:
+    sol:
+    sup:
+    hurts:
+    curl:
+    wrap:
+    cot:
+    sap:
+    scarf:
+    scar:
   common:
-  - the
-  - of
-  - and
-  - to
-  - in
-  - I
-  - that
-  - was
-  - his
-  - he
-  - it
-  - with
-  - is
-  - for
-  - as
-  - had
-  - you
-  - not
-  - be
-  - her
-  - on
-  - at
-  - by
-  - which
-  - have
-  - or
-  - from
-  - this
-  - him
-  - but
-  - all
-  - she
-  - they
-  - were
-  - my
-  - are
-  - me
-  - one
-  - their
-  - so
-  - an
-  - said
-  - them
-  - we
-  - who
-  - would
-  - been
-  - will
-  - no
-  - when
-  - there
-  - if
-  - more
-  - out
-  - up
-  - into
-  - do
-  - any
-  - your
-  - what
-  - has
-  - man
-  - could
-  - other
-  - than
-  - our
-  - some
-  - very
-  - time
-  - upon
-  - about
-  - may
-  - its
-  - only
-  - now
-  - like
-  - little
-  - then
-  - can
-  - should
-  - made
-  - did
-  - us
-  - such
-  - a
-  - great
-  - before
-  - must
-  - two
-  - these
-  - see
-  - know
-  - over
-  - much
-  - down
-  - after
-  - first
-  - Mr.
-  - good
-  - men
+    the:
+    of:
+    and:
+    to:
+    in:
+    I:
+    that:
+    was:
+    his:
+    he:
+    it:
+    with:
+    is:
+    for:
+    as:
+    had:
+    you:
+    not:
+    be:
+    her:
+    on:
+    at:
+    by:
+    which:
+    have:
+    or:
+    from:
+    this:
+    him:
+    but:
+    all:
+    she:
+    they:
+    were:
+    my:
+    are:
+    me:
+    one:
+    their:
+    so:
+    an:
+    said:
+    them:
+    we:
+    who:
+    would:
+    been:
+    will:
+    no:
+    when:
+    there:
+    if:
+    more:
+    out:
+    up:
+    into:
+    do:
+    any:
+    your:
+    what:
+    has:
+    man:
+    could:
+    other:
+    than:
+    our:
+    some:
+    very:
+    time:
+    upon:
+    about:
+    may:
+    its:
+    only:
+    now:
+    like:
+    little:
+    then:
+    can:
+    should:
+    made:
+    did:
+    us:
+    such:
+    a:
+    great:
+    before:
+    must:
+    two:
+    these:
+    see:
+    know:
+    over:
+    much:
+    down:
+    after:
+    first:
+    Mr.:
+    good:
+    men:

--- a/gameboy.yml
+++ b/gameboy.yml
@@ -23,1187 +23,1187 @@ layout: |2
 
 dictionaries:
   simple:
-  - the
-  - of
-  - and
-  - to
-  - in
-  - I
-  - that
-  - was
-  - his
-  - he
-  - it
-  - with
-  - is
-  - for
-  - as
-  - had
-  - you
-  - not
-  - be
-  - her
-  - "on"
-  - at
-  - by
-  - which
-  - have
-  - or
-  - from
-  - this
-  - him
-  - but
-  - all
-  - she
-  - they
-  - were
-  - my
-  - are
-  - me
-  - one
-  - their
-  - so
-  - an
-  - said
-  - them
-  - we
-  - who
-  - would
-  - been
-  - will
-  - "no"
-  - when
-  - there
-  - if
-  - more
-  - out
-  - up
-  - into
-  - do
-  - any
-  - your
-  - what
-  - has
-  - man
-  - could
-  - other
-  - than
-  - our
-  - some
-  - very
-  - time
-  - upon
-  - about
-  - may
-  - its
-  - only
-  - now
-  - like
-  - little
-  - then
-  - can
-  - should
-  - made
-  - did
-  - us
-  - such
-  - a
-  - great
-  - before
-  - must
-  - two
-  - these
-  - see
-  - know
-  - over
-  - much
-  - down
-  - after
-  - first
-  - Mr.
-  - good
-  - men
-  - own
-  - never
-  - most
-  - old
-  - shall
-  - day
-  - where
-  - those
-  - came
-  - come
-  - himself
-  - way
-  - work
-  - life
-  - without
-  - go
-  - make
-  - well
-  - through
-  - being
-  - long
-  - say
-  - might
-  - how
-  - am
-  - too
-  - even
-  - def
-  - again
-  - many
-  - back
-  - here
-  - think
-  - every
-  - people
-  - went
-  - same
-  - last
-  - thought
-  - away
-  - under
-  - take
-  - found
-  - hand
-  - eyes
-  - still
-  - place
-  - while
-  - just
-  - also
-  - young
-  - yet
-  - though
-  - against
-  - things
-  - get
-  - ever
-  - give
-  - god
-  - years
-  - "off"
-  - face
-  - nothing
-  - right
-  - once
-  - another
-  - left
-  - part
-  - saw
-  - house
-  - world
-  - head
-  - three
-  - took
-  - new
-  - love
-  - always
-  - Mrs.
-  - put
-  - night
-  - each
-  - king
-  - between
-  - tell
-  - mind
-  - heart
-  - few
-  - because
-  - thing
-  - whom
-  - far
-  - seemed
-  - looked
-  - called
-  - whole
-  - set
-  - both
-  - got
-  - find
-  - done
-  - heard
-  - look
-  - name
-  - days
-  - told
-  - let
-  - lord
-  - country
-  - asked
-  - going
-  - seen
-  - better
-  - having
-  - home
-  - knew
-  - side
-  - something
-  - moment
-  - father
-  - among
-  - course
-  - hands
-  - woman
-  - enough
-  - words
-  - mother
-  - soon
-  - full
-  - end
-  - gave
-  - room
-  - almost
-  - small
-  - thou
-  - cannot
-  - water
-  - want
-  - however
-  - light
-  - quite
-  - brought
-  - nor
-  - word
-  - whose
-  - given
-  - door
-  - best
-  - turned
-  - taken
-  - does
-  - use
-  - morning
-  - myself
-  - felt
-  - until
-  - since
-  - power
-  - themselves
-  - used
-  - rather
-  - began
-  - present
-  - voice
-  - others
-  - white
-  - works
-  - less
-  - money
-  - next
-  - poor
-  - death
-  - stood
-  - form
-  - within
-  - together
-  - till
-  - thy
-  - large
-  - matter
-  - kind
-  - often
-  - certain
-  - herself
-  - year
-  - friend
-  - half
-  - order
-  - round
-  - "true"
-  - anything
-  - keep
-  - sent
-  - wife
-  - means
-  - believe
-  - passed
-  - feet
-  - near
-  - public
-  - state
-  - son
-  - hundred
-  - children
-  - thus
-  - hope
-  - alone
-  - above
-  - case
-  - dear
-  - thee
-  - says
-  - person
-  - high
-  - read
-  - city
-  - already
-  - received
-  - fact
-  - gone
-  - girl
-  - known
-  - hear
-  - times
-  - least
-  - perhaps
-  - sure
-  - indeed
-  - English
-  - open
-  - body
-  - itself
-  - along
-  - land
-  - return
-  - leave
-  - air
-  - nature
-  - answered
-  - either
-  - law
-  - help
-  - lay
-  - point
-  - child
-  - letter
-  - four
-  - wish
-  - fire
-  - cried
-  - women
-  - speak
-  - number
-  - therefore
-  - hour
-  - friends
-  - held
-  - free
-  - war
-  - during
-  - several
-  - business
-  - whether
-  - manner
-  - second
-  - reason
-  - replied
-  - united
-  - call
-  - general
-  - why
-  - behind
-  - became
-  - John
-  - become
-  - dead
-  - earth
-  - boy
-  - lost
-  - forth
-  - thousand
-  - looking
-  - I'll
-  - family
-  - soul
-  - feel
-  - coming
-  - England
-  - spirit
-  - question
-  - care
-  - truth
-  - ground
-  - really
-  - rest
-  - mean
-  - different
-  - making
-  - possible
-  - fell
-  - towards
-  - human
-  - kept
-  - short
-  - town
-  - following
-  - need
-  - cause
-  - met
-  - evening
-  - returned
-  - five
-  - strong
-  - able
-  - French
-  - live
-  - lady
-  - subject
-  - answer
-  - sea
-  - fear
-  - understand
-  - hard
-  - terms
-  - doubt
-  - around
-  - ask
-  - arms
-  - turn
-  - sense
-  - seems
-  - black
-  - bring
-  - followed
-  - beautiful
-  - close
-  - dark
-  - hold
-  - character
-  - sort
-  - sight
-  - ten
-  - show
-  - party
-  - fine
-  - ready
-  - story
-  - common
-  - book
-  - electronic
-  - talk
-  - account
-  - mark
-  - interest
-  - written
-  - can't
-  - bed
-  - necessary
-  - age
-  - else
-  - force
-  - idea
-  - longer
-  - art
-  - spoke
-  - across
-  - brother
-  - early
-  - ought
-  - sometimes
-  - line
-  - saying
-  - table
-  - appeared
-  - river
-  - continued
-  - eye
-  - sun
-  - information
-  - later
-  - everything
-  - reached
-  - suddenly
-  - past
-  - hours
-  - strange
-  - deep
-  - change
-  - miles
-  - feeling
-  - act
-  - meet
-  - paid
-  - further
-  - purpose
-  - happy
-  - added
-  - seem
-  - taking
-  - blood
-  - rose
-  - south
-  - beyond
-  - cold
-  - neither
-  - forward
-  - view
-  - I've
-  - position
-  - sound
-  - none
-  - entered
-  - clear
-  - road
-  - late
-  - stand
-  - suppose
-  - daughter
-  - real
-  - nearly
-  - mine
-  - laws
-  - knowledge
-  - comes
-  - toward
-  - bad
-  - cut
-  - copy
-  - husband
-  - six
-  - France
-  - living
-  - peace
-  - didn't
-  - low
-  - north
-  - remember
-  - effect
-  - natural
-  - pretty
-  - fall
-  - fair
-  - service
-  - below
-  - except
-  - American
-  - hair
-  - London
-  - laid
-  - pass
-  - led
-  - copyright
-  - doing
-  - army
-  - run
-  - horse
-  - future
-  - opened
-  - pleasure
-  - history
-  - west
-  - pay
-  - red
-  - hath
-  - note
-  - although
-  - wanted
-  - gold
-  - makes
-  - desire
-  - play
-  - master
-  - office
-  - tried
-  - front
-  - big
-  - Dr.
-  - lived
-  - certainly
-  - wind
-  - receive
-  - attention
-  - government
-  - unto
-  - church
-  - strength
-  - length
-  - company
-  - placed
-  - paper
-  - letters
-  - probably
-  - glad
-  - important
-  - especially
-  - greater
-  - yourself
-  - fellow
-  - bear
-  - opinion
-  - window
-  - ran
-  - faith
-  - ago
-  - agreement
-  - charge
-  - beauty
-  - lips
-  - remained
-  - arm
-  - latter
-  - duty
-  - send
-  - distance
-  - silence
-  - foot
-  - wild
-  - object
-  - die
-  - save
-  - gentleman
-  - trees
-  - green
-  - trouble
-  - smile
-  - books
-  - wrong
-  - various
-  - sleep
-  - persons
-  - blockquote
-  - happened
-  - particular
-  - drew
-  - minutes
-  - hardly
-  - walked
-  - chief
-  - chance
-  - according
-  - beginning
-  - action
-  - deal
-  - loved
-  - visit
-  - thinking
-  - follow
-  - standing
-  - knows
-  - try
-  - presence
-  - heavy
-  - sweet
-  - plain
-  - donations
-  - immediately
-  - wrote
-  - mouth
-  - rich
-  - thoughts
-  - months
-  - won't
-  - afraid
-  - Paris
-  - single
-  - joy
-  - enemy
-  - broken
-  - unless
-  - states
-  - ship
-  - condition
-  - carry
-  - exclaimed
-  - including
-  - filled
-  - seeing
-  - influence
-  - write
-  - boys
-  - appear
-  - outside
-  - secret
-  - parts
-  - please
-  - appearance
-  - evil
-  - march
-  - George
-  - whatever
-  - slowly
-  - tears
-  - horses
-  - places
-  - caught
-  - stay
-  - instead
-  - struck
-  - blue
-  - York
-  - impossible
-  - period
-  - sister
-  - battle
-  - school
-  - Mary
-  - raised
-  - occasion
-  - married
-  - man's
-  - former
-  - food
-  - youth
-  - learned
-  - merely
-  - reach
-  - system
-  - twenty
-  - dinner
-  - quiet
-  - easily
-  - moved
-  - afterwards
-  - giving
-  - walk
-  - stopped
-  - laughed
-  - language
-  - expression
-  - week
-  - hall
-  - danger
-  - property
-  - wonder
-  - usual
-  - figure
-  - born
-  - court
-  - generally
-  - grew
-  - showed
-  - getting
-  - ancient
-  - respect
-  - third
-  - worth
-  - simple
-  - tree
-  - leaving
-  - remain
-  - society
-  - fight
-  - wall
-  - result
-  - heaven
-  - William
-  - started
-  - command
-  - tone
-  - regard
-  - expected
-  - mere
-  - month
-  - beside
-  - silent
-  - perfect
-  - experience
-  - street
-  - writing
-  - goes
-  - circumstances
-  - entirely
-  - fresh
-  - duke
-  - covered
-  - bound
-  - east
-  - wood
-  - stone
-  - quickly
-  - notice
-  - bright
-  - Christ
-  - boat
-  - noble
-  - meant
-  - somewhat
-  - sudden
-  - value
-  - direction
-  - chair
-  - due
-  - support
-  - Tom
-  - date
-  - waiting
-  - Christian
-  - village
-  - lives
-  - reading
-  - agree
-  - lines
-  - considered
-  - field
-  - observed
-  - scarcely
-  - wished
-  - wait
-  - greatest
-  - permission
-  - success
-  - piece
-  - British
-  - Charles
-  - formed
-  - speaking
-  - trying
-  - conversation
-  - proper
-  - hill
-  - music
-  - opportunity
-  - that's
-  - German
-  - afternoon
-  - cry
-  - cost
-  - allowed
-  - girls
-  - considerable
-  - broke
-  - honour
-  - seven
-  - private
-  - sit
-  - news
-  - top
-  - scene
-  - discovered
-  - marriage
-  - step
-  - garden
-  - race
-  - begin
-  - per
-  - individual
-  - sitting
-  - learn
-  - political
-  - difficult
-  - bit
-  - speech
-  - Henry
-  - lie
-  - cast
-  - eat
-  - authority
-  - etc.
-  - floor
-  - ill
-  - ways
-  - officers
-  - offered
-  - original
-  - happiness
-  - flowers
-  - produced
-  - summer
-  - provide
-  - study
-  - religion
-  - picture
-  - walls
-  - personal
-  - America
-  - watch
-  - pleased
-  - leaves
-  - declared
-  - hot
-  - understood
-  - effort
-  - prepared
-  - escape
-  - attempt
-  - supposed
-  - killed
-  - fast
-  - author
-  - Indian
-  - brown
-  - determined
-  - pain
-  - spring
-  - takes
-  - drawn
-  - soldiers
-  - houses
-  - beneath
-  - talking
-  - turning
-  - century
-  - steps
-  - intended
-  - soft
-  - straight
-  - matters
-  - likely
-  - corner
-  - trademark
-  - justice
-  - simply
-  - produce
-  - trust
-  - appears
-  - Rome
-  - laugh
-  - forget
-  - Europe
-  - passage
-  - eight
-  - closed
-  - ourselves
-  - gives
-  - dress
-  - passing
-  - terrible
-  - required
-  - medium
-  - efforts
-  - sake
-  - breath
-  - wise
-  - ladies
-  - possession
-  - pleasant
-  - perfectly
-  - memory
-  - usually
-  - grave
-  - fixed
-  - modern
-  - spot
-  - troops
-  - rise
-  - break
-  - fifty
-  - island
-  - meeting
-  - camp
-  - nation
-  - existence
-  - reply
-  - I'd
-  - copies
-  - sky
-  - touch
-  - equal
-  - fortune
-  - shore
-  - domain
-  - named
-  - situation
-  - looks
-  - promise
-  - orders
-  - degree
-  - middle
-  - winter
-  - plan
-  - spent
-  - allow
-  - pale
-  - conduct
-  - running
-  - religious
-  - surprise
-  - minute
-  - Roman
-  - cases
-  - shot
-  - lead
-  - move
-  - names
+    the:
+    of:
+    and:
+    to:
+    in:
+    I:
+    that:
+    was:
+    his:
+    he:
+    it:
+    with:
+    is:
+    for:
+    as:
+    had:
+    you:
+    not:
+    be:
+    her:
+    "on":
+    at:
+    by:
+    which:
+    have:
+    or:
+    from:
+    this:
+    him:
+    but:
+    all:
+    she:
+    they:
+    were:
+    my:
+    are:
+    me:
+    one:
+    their:
+    so:
+    an:
+    said:
+    them:
+    we:
+    who:
+    would:
+    been:
+    will:
+    "no":
+    when:
+    there:
+    if:
+    more:
+    out:
+    up:
+    into:
+    do:
+    any:
+    your:
+    what:
+    has:
+    man:
+    could:
+    other:
+    than:
+    our:
+    some:
+    very:
+    time:
+    upon:
+    about:
+    may:
+    its:
+    only:
+    now:
+    like:
+    little:
+    then:
+    can:
+    should:
+    made:
+    did:
+    us:
+    such:
+    a:
+    great:
+    before:
+    must:
+    two:
+    these:
+    see:
+    know:
+    over:
+    much:
+    down:
+    after:
+    first:
+    Mr.:
+    good:
+    men:
+    own:
+    never:
+    most:
+    old:
+    shall:
+    day:
+    where:
+    those:
+    came:
+    come:
+    himself:
+    way:
+    work:
+    life:
+    without:
+    go:
+    make:
+    well:
+    through:
+    being:
+    long:
+    say:
+    might:
+    how:
+    am:
+    too:
+    even:
+    def:
+    again:
+    many:
+    back:
+    here:
+    think:
+    every:
+    people:
+    went:
+    same:
+    last:
+    thought:
+    away:
+    under:
+    take:
+    found:
+    hand:
+    eyes:
+    still:
+    place:
+    while:
+    just:
+    also:
+    young:
+    yet:
+    though:
+    against:
+    things:
+    get:
+    ever:
+    give:
+    god:
+    years:
+    "off":
+    face:
+    nothing:
+    right:
+    once:
+    another:
+    left:
+    part:
+    saw:
+    house:
+    world:
+    head:
+    three:
+    took:
+    new:
+    love:
+    always:
+    Mrs.:
+    put:
+    night:
+    each:
+    king:
+    between:
+    tell:
+    mind:
+    heart:
+    few:
+    because:
+    thing:
+    whom:
+    far:
+    seemed:
+    looked:
+    called:
+    whole:
+    set:
+    both:
+    got:
+    find:
+    done:
+    heard:
+    look:
+    name:
+    days:
+    told:
+    let:
+    lord:
+    country:
+    asked:
+    going:
+    seen:
+    better:
+    having:
+    home:
+    knew:
+    side:
+    something:
+    moment:
+    father:
+    among:
+    course:
+    hands:
+    woman:
+    enough:
+    words:
+    mother:
+    soon:
+    full:
+    end:
+    gave:
+    room:
+    almost:
+    small:
+    thou:
+    cannot:
+    water:
+    want:
+    however:
+    light:
+    quite:
+    brought:
+    nor:
+    word:
+    whose:
+    given:
+    door:
+    best:
+    turned:
+    taken:
+    does:
+    use:
+    morning:
+    myself:
+    felt:
+    until:
+    since:
+    power:
+    themselves:
+    used:
+    rather:
+    began:
+    present:
+    voice:
+    others:
+    white:
+    works:
+    less:
+    money:
+    next:
+    poor:
+    death:
+    stood:
+    form:
+    within:
+    together:
+    till:
+    thy:
+    large:
+    matter:
+    kind:
+    often:
+    certain:
+    herself:
+    year:
+    friend:
+    half:
+    order:
+    round:
+    "true":
+    anything:
+    keep:
+    sent:
+    wife:
+    means:
+    believe:
+    passed:
+    feet:
+    near:
+    public:
+    state:
+    son:
+    hundred:
+    children:
+    thus:
+    hope:
+    alone:
+    above:
+    case:
+    dear:
+    thee:
+    says:
+    person:
+    high:
+    read:
+    city:
+    already:
+    received:
+    fact:
+    gone:
+    girl:
+    known:
+    hear:
+    times:
+    least:
+    perhaps:
+    sure:
+    indeed:
+    English:
+    open:
+    body:
+    itself:
+    along:
+    land:
+    return:
+    leave:
+    air:
+    nature:
+    answered:
+    either:
+    law:
+    help:
+    lay:
+    point:
+    child:
+    letter:
+    four:
+    wish:
+    fire:
+    cried:
+    women:
+    speak:
+    number:
+    therefore:
+    hour:
+    friends:
+    held:
+    free:
+    war:
+    during:
+    several:
+    business:
+    whether:
+    manner:
+    second:
+    reason:
+    replied:
+    united:
+    call:
+    general:
+    why:
+    behind:
+    became:
+    John:
+    become:
+    dead:
+    earth:
+    boy:
+    lost:
+    forth:
+    thousand:
+    looking:
+    I'll:
+    family:
+    soul:
+    feel:
+    coming:
+    England:
+    spirit:
+    question:
+    care:
+    truth:
+    ground:
+    really:
+    rest:
+    mean:
+    different:
+    making:
+    possible:
+    fell:
+    towards:
+    human:
+    kept:
+    short:
+    town:
+    following:
+    need:
+    cause:
+    met:
+    evening:
+    returned:
+    five:
+    strong:
+    able:
+    French:
+    live:
+    lady:
+    subject:
+    answer:
+    sea:
+    fear:
+    understand:
+    hard:
+    terms:
+    doubt:
+    around:
+    ask:
+    arms:
+    turn:
+    sense:
+    seems:
+    black:
+    bring:
+    followed:
+    beautiful:
+    close:
+    dark:
+    hold:
+    character:
+    sort:
+    sight:
+    ten:
+    show:
+    party:
+    fine:
+    ready:
+    story:
+    common:
+    book:
+    electronic:
+    talk:
+    account:
+    mark:
+    interest:
+    written:
+    can't:
+    bed:
+    necessary:
+    age:
+    else:
+    force:
+    idea:
+    longer:
+    art:
+    spoke:
+    across:
+    brother:
+    early:
+    ought:
+    sometimes:
+    line:
+    saying:
+    table:
+    appeared:
+    river:
+    continued:
+    eye:
+    sun:
+    information:
+    later:
+    everything:
+    reached:
+    suddenly:
+    past:
+    hours:
+    strange:
+    deep:
+    change:
+    miles:
+    feeling:
+    act:
+    meet:
+    paid:
+    further:
+    purpose:
+    happy:
+    added:
+    seem:
+    taking:
+    blood:
+    rose:
+    south:
+    beyond:
+    cold:
+    neither:
+    forward:
+    view:
+    I've:
+    position:
+    sound:
+    none:
+    entered:
+    clear:
+    road:
+    late:
+    stand:
+    suppose:
+    daughter:
+    real:
+    nearly:
+    mine:
+    laws:
+    knowledge:
+    comes:
+    toward:
+    bad:
+    cut:
+    copy:
+    husband:
+    six:
+    France:
+    living:
+    peace:
+    didn't:
+    low:
+    north:
+    remember:
+    effect:
+    natural:
+    pretty:
+    fall:
+    fair:
+    service:
+    below:
+    except:
+    American:
+    hair:
+    London:
+    laid:
+    pass:
+    led:
+    copyright:
+    doing:
+    army:
+    run:
+    horse:
+    future:
+    opened:
+    pleasure:
+    history:
+    west:
+    pay:
+    red:
+    hath:
+    note:
+    although:
+    wanted:
+    gold:
+    makes:
+    desire:
+    play:
+    master:
+    office:
+    tried:
+    front:
+    big:
+    Dr.:
+    lived:
+    certainly:
+    wind:
+    receive:
+    attention:
+    government:
+    unto:
+    church:
+    strength:
+    length:
+    company:
+    placed:
+    paper:
+    letters:
+    probably:
+    glad:
+    important:
+    especially:
+    greater:
+    yourself:
+    fellow:
+    bear:
+    opinion:
+    window:
+    ran:
+    faith:
+    ago:
+    agreement:
+    charge:
+    beauty:
+    lips:
+    remained:
+    arm:
+    latter:
+    duty:
+    send:
+    distance:
+    silence:
+    foot:
+    wild:
+    object:
+    die:
+    save:
+    gentleman:
+    trees:
+    green:
+    trouble:
+    smile:
+    books:
+    wrong:
+    various:
+    sleep:
+    persons:
+    blockquote:
+    happened:
+    particular:
+    drew:
+    minutes:
+    hardly:
+    walked:
+    chief:
+    chance:
+    according:
+    beginning:
+    action:
+    deal:
+    loved:
+    visit:
+    thinking:
+    follow:
+    standing:
+    knows:
+    try:
+    presence:
+    heavy:
+    sweet:
+    plain:
+    donations:
+    immediately:
+    wrote:
+    mouth:
+    rich:
+    thoughts:
+    months:
+    won't:
+    afraid:
+    Paris:
+    single:
+    joy:
+    enemy:
+    broken:
+    unless:
+    states:
+    ship:
+    condition:
+    carry:
+    exclaimed:
+    including:
+    filled:
+    seeing:
+    influence:
+    write:
+    boys:
+    appear:
+    outside:
+    secret:
+    parts:
+    please:
+    appearance:
+    evil:
+    march:
+    George:
+    whatever:
+    slowly:
+    tears:
+    horses:
+    places:
+    caught:
+    stay:
+    instead:
+    struck:
+    blue:
+    York:
+    impossible:
+    period:
+    sister:
+    battle:
+    school:
+    Mary:
+    raised:
+    occasion:
+    married:
+    man's:
+    former:
+    food:
+    youth:
+    learned:
+    merely:
+    reach:
+    system:
+    twenty:
+    dinner:
+    quiet:
+    easily:
+    moved:
+    afterwards:
+    giving:
+    walk:
+    stopped:
+    laughed:
+    language:
+    expression:
+    week:
+    hall:
+    danger:
+    property:
+    wonder:
+    usual:
+    figure:
+    born:
+    court:
+    generally:
+    grew:
+    showed:
+    getting:
+    ancient:
+    respect:
+    third:
+    worth:
+    simple:
+    tree:
+    leaving:
+    remain:
+    society:
+    fight:
+    wall:
+    result:
+    heaven:
+    William:
+    started:
+    command:
+    tone:
+    regard:
+    expected:
+    mere:
+    month:
+    beside:
+    silent:
+    perfect:
+    experience:
+    street:
+    writing:
+    goes:
+    circumstances:
+    entirely:
+    fresh:
+    duke:
+    covered:
+    bound:
+    east:
+    wood:
+    stone:
+    quickly:
+    notice:
+    bright:
+    Christ:
+    boat:
+    noble:
+    meant:
+    somewhat:
+    sudden:
+    value:
+    direction:
+    chair:
+    due:
+    support:
+    Tom:
+    date:
+    waiting:
+    Christian:
+    village:
+    lives:
+    reading:
+    agree:
+    lines:
+    considered:
+    field:
+    observed:
+    scarcely:
+    wished:
+    wait:
+    greatest:
+    permission:
+    success:
+    piece:
+    British:
+    Charles:
+    formed:
+    speaking:
+    trying:
+    conversation:
+    proper:
+    hill:
+    music:
+    opportunity:
+    that's:
+    German:
+    afternoon:
+    cry:
+    cost:
+    allowed:
+    girls:
+    considerable:
+    broke:
+    honour:
+    seven:
+    private:
+    sit:
+    news:
+    top:
+    scene:
+    discovered:
+    marriage:
+    step:
+    garden:
+    race:
+    begin:
+    per:
+    individual:
+    sitting:
+    learn:
+    political:
+    difficult:
+    bit:
+    speech:
+    Henry:
+    lie:
+    cast:
+    eat:
+    authority:
+    etc.:
+    floor:
+    ill:
+    ways:
+    officers:
+    offered:
+    original:
+    happiness:
+    flowers:
+    produced:
+    summer:
+    provide:
+    study:
+    religion:
+    picture:
+    walls:
+    personal:
+    America:
+    watch:
+    pleased:
+    leaves:
+    declared:
+    hot:
+    understood:
+    effort:
+    prepared:
+    escape:
+    attempt:
+    supposed:
+    killed:
+    fast:
+    author:
+    Indian:
+    brown:
+    determined:
+    pain:
+    spring:
+    takes:
+    drawn:
+    soldiers:
+    houses:
+    beneath:
+    talking:
+    turning:
+    century:
+    steps:
+    intended:
+    soft:
+    straight:
+    matters:
+    likely:
+    corner:
+    trademark:
+    justice:
+    simply:
+    produce:
+    trust:
+    appears:
+    Rome:
+    laugh:
+    forget:
+    Europe:
+    passage:
+    eight:
+    closed:
+    ourselves:
+    gives:
+    dress:
+    passing:
+    terrible:
+    required:
+    medium:
+    efforts:
+    sake:
+    breath:
+    wise:
+    ladies:
+    possession:
+    pleasant:
+    perfectly:
+    memory:
+    usually:
+    grave:
+    fixed:
+    modern:
+    spot:
+    troops:
+    rise:
+    break:
+    fifty:
+    island:
+    meeting:
+    camp:
+    nation:
+    existence:
+    reply:
+    I'd:
+    copies:
+    sky:
+    touch:
+    equal:
+    fortune:
+    shore:
+    domain:
+    named:
+    situation:
+    looks:
+    promise:
+    orders:
+    degree:
+    middle:
+    winter:
+    plan:
+    spent:
+    allow:
+    pale:
+    conduct:
+    running:
+    religious:
+    surprise:
+    minute:
+    Roman:
+    cases:
+    shot:
+    lead:
+    move:
+    names:
   common:
-  - you
-  - I
-  - to
-  - the
-  - a
-  - and
-  - that
-  - it
-  - of
-  - me
-  - what
-  - is
-  - in
-  - this
-  - know
-  - I'm
-  - for
-  - no
-  - have
-  - my
-  - don't
-  - just
-  - not
-  - do
-  - be
-  - on
-  - your
-  - was
-  - we
-  - it's
-  - with
-  - so
-  - but
-  - all
-  - well
-  - are
-  - he
-  - oh
-  - about
-  - right
-  - you're
-  - get
-  - here
-  - out
-  - going
-  - like
-  - yeah
-  - if
-  - her
-  - she
-  - can
-  - up
-  - want
-  - think
-  - that's
-  - now
-  - go
-  - him
-  - at
-  - how
-  - got
-  - there
-  - one
-  - did
-  - why
-  - see
-  - come
-  - good
-  - they
-  - really
-  - as
-  - would
-  - look
-  - when
-  - time
-  - will
-  - okay
-  - back
-  - can't
-  - mean
-  - tell
-  - I'll
-  - from
-  - hey
-  - were
-  - he's
-  - could
-  - didn't
-  - yes
-  - his
-  - been
-  - or
-  - something
-  - who
-  - because
-  - some
-  - had
-  - then
-  - say
-  - take
-  - an
-  - way
-  - us
-  - little
-  - make
-  - need
-  - gonna
-  - never
-  - we're
-  - too
-  - love
-  - she's
-  - I've
-  - sure
-  - them
-  - more
-  - over
-  - our
-  - sorry
-  - where
-  - what's
-  - let
-  - thing
-  - am
-  - maybe
-  - down
-  - man
-  - has
-  - uh
-  - very
-  - by
-  - there's
-  - should
-  - anything
-  - said
-  - much
-  - any
-  - life
-  - even
-  - off
-  - please
-  - doing
-  - thank
-  - give
-  - only
-  - thought
-  - help
-  - two
-  - talk
-  - people
-  - god
-  - still
-  - wait
-  - into
-  - find
-  - nothing
-  - again
-  - things
-  - let's
-  - doesn't
-  - call
-  - told
-  - great
-  - before
-  - better
-  - ever
-  - night
-  - than
-  - away
-  - first
-  - believe
-  - other
-  - feel
-  - everything
-  - work
-  - you've
-  - fine
-  - home
-  - after
-  - last
-  - these
-  - day
-  - keep
-  - does
-  - put
-  - around
-  - stop
-  - they're
-  - I'd
-  - guy
-  - long
-  - isn't
-  - always
-  - listen
-  - wanted
-  - guys
-  - huh
-  - those
-  - big
-  - lot
+    you:
+    I:
+    to:
+    the:
+    a:
+    and:
+    that:
+    it:
+    of:
+    me:
+    what:
+    is:
+    in:
+    this:
+    know:
+    I'm:
+    for:
+    no:
+    have:
+    my:
+    don't:
+    just:
+    not:
+    do:
+    be:
+    on:
+    your:
+    was:
+    we:
+    it's:
+    with:
+    so:
+    but:
+    all:
+    well:
+    are:
+    he:
+    oh:
+    about:
+    right:
+    you're:
+    get:
+    here:
+    out:
+    going:
+    like:
+    yeah:
+    if:
+    her:
+    she:
+    can:
+    up:
+    want:
+    think:
+    that's:
+    now:
+    go:
+    him:
+    at:
+    how:
+    got:
+    there:
+    one:
+    did:
+    why:
+    see:
+    come:
+    good:
+    they:
+    really:
+    as:
+    would:
+    look:
+    when:
+    time:
+    will:
+    okay:
+    back:
+    can't:
+    mean:
+    tell:
+    I'll:
+    from:
+    hey:
+    were:
+    he's:
+    could:
+    didn't:
+    yes:
+    his:
+    been:
+    or:
+    something:
+    who:
+    because:
+    some:
+    had:
+    then:
+    say:
+    take:
+    an:
+    way:
+    us:
+    little:
+    make:
+    need:
+    gonna:
+    never:
+    we're:
+    too:
+    love:
+    she's:
+    I've:
+    sure:
+    them:
+    more:
+    over:
+    our:
+    sorry:
+    where:
+    what's:
+    let:
+    thing:
+    am:
+    maybe:
+    down:
+    man:
+    has:
+    uh:
+    very:
+    by:
+    there's:
+    should:
+    anything:
+    said:
+    much:
+    any:
+    life:
+    even:
+    off:
+    please:
+    doing:
+    thank:
+    give:
+    only:
+    thought:
+    help:
+    two:
+    talk:
+    people:
+    god:
+    still:
+    wait:
+    into:
+    find:
+    nothing:
+    again:
+    things:
+    let's:
+    doesn't:
+    call:
+    told:
+    great:
+    before:
+    better:
+    ever:
+    night:
+    than:
+    away:
+    first:
+    believe:
+    other:
+    feel:
+    everything:
+    work:
+    you've:
+    fine:
+    home:
+    after:
+    last:
+    these:
+    day:
+    keep:
+    does:
+    put:
+    around:
+    stop:
+    they're:
+    I'd:
+    guy:
+    long:
+    isn't:
+    always:
+    listen:
+    wanted:
+    guys:
+    huh:
+    those:
+    big:
+    lot:

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,0 +1,1 @@
+nightly

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -1,38 +1,33 @@
-use crate::typing::ChoicesState;
 use crate::configuration::Configuration;
+use crate::typing::ChoicesState;
 use crate::xdo::XdoState;
 
 pub struct Doer {
-    pub state : ChoicesState,
-    xstate : XdoState,
+    pub state: ChoicesState,
+    xstate: XdoState,
 }
 
 impl Doer {
-    pub fn new(conf : Configuration, target : &str, window_index : usize, active : bool) -> Self {
+    pub fn new(conf: Configuration, target: &str, window_index: usize, active: bool) -> Self {
         let state = ChoicesState::new(conf, 3);
         let xstate = XdoState::new(target, window_index, active);
 
-        Doer {
-            state,
-            xstate,
-        }
+        Doer { state, xstate }
     }
-    
-    pub fn check_and_do(&mut self, input : &str) -> bool {
+
+    pub fn check_and_do(&mut self, input: &str) -> bool {
         let keys = self.state.consume(input);
 
         match keys {
             Some(k) => {
                 self.xstate.send_key(&k);
                 true
-            },
-            None => {
-                false
-            },
+            }
+            None => false,
         }
     }
 
-    pub fn mapped_direct_send_down(&mut self, input : &str) -> bool {
+    pub fn mapped_direct_send_down(&mut self, input: &str) -> bool {
         if let Some(v) = self.state.conf.direct.get(input) {
             self.xstate.send_key_down(v);
             true
@@ -41,7 +36,7 @@ impl Doer {
         }
     }
 
-    pub fn mapped_direct_send_up(&mut self, input : &str) -> bool {
+    pub fn mapped_direct_send_up(&mut self, input: &str) -> bool {
         if let Some(v) = self.state.conf.direct.get(input) {
             self.xstate.send_key_up(v);
             true
@@ -50,7 +45,7 @@ impl Doer {
         }
     }
 
-    pub fn mapped_direct_send(&mut self, input : &str) -> bool {
+    pub fn mapped_direct_send(&mut self, input: &str) -> bool {
         if let Some(v) = self.state.conf.direct.get(input) {
             self.xstate.send_key(v);
             true
@@ -59,15 +54,15 @@ impl Doer {
         }
     }
 
-    pub fn direct_send_down(&mut self, input : &str) {
+    pub fn direct_send_down(&mut self, input: &str) {
         self.xstate.send_key_down(input);
     }
 
-    pub fn direct_send_up(&mut self, input : &str) {
+    pub fn direct_send_up(&mut self, input: &str) {
         self.xstate.send_key_up(input);
     }
 
-    pub fn direct_send(&mut self, input : &str) {
+    pub fn direct_send(&mut self, input: &str) {
         self.xstate.send_key(input);
     }
 }

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -1,19 +1,65 @@
-use std::fs::File;
-use serde::{Deserialize};
+use serde::Deserialize;
 use std::collections::HashMap;
+use std::fs::File;
 
 #[derive(Deserialize)]
 pub struct Configuration {
-    pub dictionaries: HashMap<String, Vec<String>>,
+    pub dictionaries: HashMap<String, HashMap<String, String>>,
     pub keys: HashMap<String, String>,
     pub direct: HashMap<String, String>,
     pub layout: String,
 }
 
+pub type DictEntry<'a> = (&'a String, &'a String);
+pub type HardDictEntry = (String, String);
+
+pub trait DisplayableTypeable: Sized {
+    fn display(&self) -> String;
+    fn matchable(&self) -> String;
+}
+
+impl<'a> DisplayableTypeable for DictEntry<'a> {
+    fn display(&self) -> String {
+        self.0.clone()
+    }
+
+    fn matchable(&self) -> String {
+        if self.1 == "" {
+            self.0.clone()
+        } else {
+            self.1.clone()
+        }
+    }
+}
+
+impl DisplayableTypeable for HardDictEntry {
+    fn display(&self) -> String {
+        self.0.clone()
+    }
+
+    fn matchable(&self) -> String {
+        // For some reason loading an empty value for a dict entry is '~'.
+        if self.1 == "~" {
+            self.0.clone()
+        } else {
+            self.1.clone()
+        }
+    }
+}
+pub trait HardCopyable {
+    fn hard_copy(&self) -> (String, String);
+}
+
+impl<'a> HardCopyable for DictEntry<'a> {
+    fn hard_copy(&self) -> HardDictEntry {
+        (self.0.clone(), self.1.clone())
+    }
+}
+
 impl Configuration {
-    pub fn new(file_name : &str) -> Result<Configuration, Box<dyn std::error::Error>> {
+    pub fn new(file_name: &str) -> Result<Configuration, Box<dyn std::error::Error>> {
         let file = File::open(file_name)?;
-        let conf : Configuration = serde_yaml::from_reader(file)?;
+        let conf: Configuration = serde_yaml::from_reader(file)?;
         Ok(conf)
     }
 }

--- a/src/display.rs
+++ b/src/display.rs
@@ -1,45 +1,54 @@
-use std::collections::{HashMap, VecDeque};
-use crate::ui_trait::UI;
 use crate::backend::Doer;
+use crate::configuration::{DisplayableTypeable, HardDictEntry};
+use crate::ui_trait::UI;
+use std::collections::{HashMap, VecDeque};
 use std::io::stdin;
 
 pub trait Renderable {
-    fn render(&self, fmt : &str) -> String;
+    fn render(&self, fmt: &str) -> String;
 }
 
-impl Renderable for HashMap<String,String> {
-    fn render(&self, fmt : &str) -> String {
+impl Renderable for HashMap<String, HardDictEntry> {
+    fn render(&self, fmt: &str) -> String {
         let mut res = fmt.to_string();
 
-        for (k,v) in self {
+        for (k, v) in self {
             let to_rep = format!("{{{}}}", k);
-            let replacement = format!("{}", v);
+            let replacement = format!("{}", v.display());
             res = res.replace(&to_rep, &replacement);
         }
-        
+
         res
     }
 }
 
-impl Renderable for HashMap<String,VecDeque<String>> {
-    fn render(&self, fmt : &str) -> String {
+impl Renderable for HashMap<String, VecDeque<HardDictEntry>> {
+    fn render(&self, fmt: &str) -> String {
         let mut res = fmt.to_string();
 
-        for (k,v) in self {
+        for (k, v) in self {
             let to_rep = format!("{{q:{}}}", k);
             let (s1, s2) = v.as_slices();
-            let str1 = s1.join(" ");
-            let str2 = s2.join(" ");
+            let str1 = s1
+                .iter()
+                .map(|s| s.display())
+                .collect::<Vec<String>>()
+                .join(" ");
+            let str2 = s2
+                .iter()
+                .map(|s| s.display())
+                .collect::<Vec<String>>()
+                .join(" ");
             let replacement = format!("{}", [str1, str2].join(" "));
             res = res.replace(&to_rep, &replacement);
         }
-        
+
         res
     }
 }
 
 pub struct TextDisplay {
-    doer : Doer,
+    doer: Doer,
 }
 
 impl TextDisplay {
@@ -51,10 +60,8 @@ impl TextDisplay {
 }
 
 impl UI for TextDisplay {
-    fn new(doer : Doer) -> Self {
-        TextDisplay {
-            doer
-        }
+    fn new(doer: Doer) -> Self {
+        TextDisplay { doer }
     }
 
     fn main_loop(&mut self) -> Result<!, Box<dyn std::error::Error>> {

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -1,13 +1,13 @@
-use orbtk::prelude::*;
 use crate::backend::Doer;
 use crate::ui_trait::UI;
+use orbtk::prelude::*;
 
 pub struct Gui {
-    doer : Doer,
+    doer: Doer,
 }
 
 impl UI for Gui {
-    fn new(mut doer : Doer) -> Self {
+    fn new(doer: Doer) -> Self {
         //input.handle(move |me, ev| match ev {
         //    Event::KeyDown => {
         //        println!("Stuff happened!");
@@ -18,11 +18,9 @@ impl UI for Gui {
         //    _ => false,
         //});
 
-        Gui {
-            doer,
-        }
+        Gui { doer }
     }
-        
+
     fn main_loop(&mut self) -> Result<!, Box<dyn std::error::Error>> {
         let _app = Application::new()
             .window(|ctx| {
@@ -35,7 +33,7 @@ impl UI for Gui {
                             .text("Hi!")
                             .v_align("center")
                             .h_align("center")
-                            .build(ctx)
+                            .build(ctx),
                     )
                     .build(ctx)
             })

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,10 @@
-#![feature(never_type)]
+#![feature(never_type, trait_alias)]
 
-use clap::{Arg, App};
+use clap::{App, Arg};
 
-mod xdo;
-mod typing;
 mod gui;
+mod typing;
+mod xdo;
 use gui::Gui;
 
 mod configuration;
@@ -28,34 +28,43 @@ fn main() -> Result<!, Box<dyn std::error::Error>> {
     let args = App::new("Typing to input")
         .author("Luke Angove <luke.angove@gmail.com>")
         .about("Converts typed into an alternate input (mostly for practicing stenography)")
-        .arg(Arg::with_name("config")
-            .short("c")
-            .long("config")
-            .takes_value(true)
-            .help("Configuration for world list mappings/conversions"))
-        .arg(Arg::with_name("window_title")
-            .required(true)
-            .index(1)
-            .help("Substring of the window title to target with converted input"))
-        .arg(Arg::with_name("window_index")
-            .short("w")
-            .long("window_index")
-            .takes_value(true)
-            .help("Index of the window to target if there are multiple matches, defaults to 0"))
-        .arg(Arg::with_name("user interface")
-            .short("i")
-            .long("interface")
-            .takes_value(true)
-            .help("Name of the interface to use"))
-        .arg(Arg::with_name("active_window")
-            .short("a")
-            .long("active")
-            .help("Activate window when sending keys, rather that running in the background")
+        .arg(
+            Arg::with_name("config")
+                .short("c")
+                .long("config")
+                .takes_value(true)
+                .help("Configuration for world list mappings/conversions"),
+        )
+        .arg(
+            Arg::with_name("window_title")
+                .required(true)
+                .index(1)
+                .help("Substring of the window title to target with converted input"),
+        )
+        .arg(
+            Arg::with_name("window_index")
+                .short("w")
+                .long("window_index")
+                .takes_value(true)
+                .help("Index of the window to target if there are multiple matches, defaults to 0"),
+        )
+        .arg(
+            Arg::with_name("user interface")
+                .short("i")
+                .long("interface")
+                .takes_value(true)
+                .help("Name of the interface to use"),
+        )
+        .arg(
+            Arg::with_name("active_window")
+                .short("a")
+                .long("active")
+                .help("Activate window when sending keys, rather that running in the background"),
         )
         .get_matches();
-    
+
     let app = args.value_of("window_title").unwrap();
-    let window_index : usize = args.value_of("window_index").unwrap_or("0").parse()?;
+    let window_index: usize = args.value_of("window_index").unwrap_or("0").parse()?;
     let conf_file = args.value_of("config").unwrap_or("config.yml");
     let interface = args.value_of("user interface").unwrap_or("tui");
     let active = args.is_present("active_window");
@@ -63,14 +72,22 @@ fn main() -> Result<!, Box<dyn std::error::Error>> {
     let conf = Configuration::new(conf_file)?;
     let doer = Doer::new(conf, app, window_index, active);
 
-    let mut ui : Box<dyn UI>;
+    let mut ui: Box<dyn UI>;
     println!("Interface: {}", interface);
     match interface {
-        "gui" => { ui = Box::new(Gui::new(doer)); }
-        "tui" => { ui = Box::new(TUI::new(doer)); }
-        "text" => { ui = Box::new(TextDisplay::new(doer)); }
-        _ => { panic!("Invalid UI!"); }
+        "gui" => {
+            ui = Box::new(Gui::new(doer));
+        }
+        "tui" => {
+            ui = Box::new(TUI::new(doer));
+        }
+        "text" => {
+            ui = Box::new(TextDisplay::new(doer));
+        }
+        _ => {
+            panic!("Invalid UI!");
+        }
     }
-    
+
     ui.main_loop()?
 }

--- a/src/typing.rs
+++ b/src/typing.rs
@@ -1,36 +1,48 @@
-use rand::thread_rng;
 use rand::rngs::ThreadRng;
 use rand::seq::SliceRandom;
-use std::collections::{HashMap, VecDeque};
+use rand::thread_rng;
 use std::cmp::min;
+use std::collections::{HashMap, VecDeque};
 
 use crate::configuration::Configuration;
+use crate::configuration::DisplayableTypeable;
+use crate::configuration::{DictEntry, HardCopyable, HardDictEntry};
 
 pub struct ChoicesState {
     pub conf: Configuration,
     rng: ThreadRng,
-    pub choices: HashMap<String, String>,
-    pub queues: HashMap<String, VecDeque<String>>,
+    pub choices: HashMap<String, HardDictEntry>,
+    pub queues: HashMap<String, VecDeque<HardDictEntry>>,
 }
 
 impl ChoicesState {
-    pub fn new(conf : Configuration, queue_size : usize) -> Self {
-        let mut choices = HashMap::<String, String>::new();
-        let mut queues = HashMap::<String, VecDeque<String>>::new();
+    pub fn new(conf: Configuration, queue_size: usize) -> Self {
+        let mut choices = HashMap::<String, HardDictEntry>::new();
+        let mut queues = HashMap::<String, VecDeque<HardDictEntry>>::new();
         let mut rng = thread_rng();
 
         for d in conf.dictionaries.keys() {
             let mut this_queue = VecDeque::new();
             this_queue.reserve(queue_size);
-            fill_queue(&choices, &mut this_queue, &conf.dictionaries[d], &mut rng);
+            fill_queue(
+                &choices,
+                &mut this_queue,
+                &conf.dictionaries[d].iter().collect(),
+                &mut rng,
+            );
             queues.insert((*d).clone(), this_queue);
         }
-        
-        for (key,dict) in &conf.keys {
+
+        for (key, dict) in &conf.keys {
             let mut queue = queues.get_mut(dict).unwrap();
             let new = queue.pop_back().unwrap();
             choices.insert(key.clone(), new);
-            fill_queue(&choices, &mut queue, &conf.dictionaries[dict], &mut rng);
+            fill_queue(
+                &choices,
+                &mut queue,
+                &conf.dictionaries[dict].iter().collect(),
+                &mut rng,
+            );
         }
 
         ChoicesState {
@@ -41,44 +53,54 @@ impl ChoicesState {
         }
     }
 
-    pub fn consume(&mut self, s : &str) -> Option<String> {
-        let mut res : Option<String> = None;
+    pub fn consume(&mut self, s: &str) -> Option<String> {
+        let mut res: Option<String> = None;
 
-        for (k,v) in &self.choices {
-            if s == v {
+        for (k, v) in &self.choices {
+            if s == v.matchable() {
                 res = Some(k.clone());
                 break;
             }
         }
- 
+
         match res {
             Some(key) => {
                 let queue_id = &self.conf.keys[&key];
                 let mut queue = self.queues.get_mut(queue_id).unwrap();
-                let dict = &self.conf.dictionaries[queue_id];
+                let dict = &self.conf.dictionaries[queue_id]
+                    .iter()
+                    .collect::<Vec<DictEntry>>();
 
                 let new = queue.pop_front().unwrap();
                 self.choices.insert(key.clone(), new);
-                fill_queue(&self.choices, &mut queue, dict, &mut self.rng);
+                fill_queue(&self.choices, &mut queue, &dict, &mut self.rng);
                 Some(key)
-            },
-            None => {
-                None
-            },
+            }
+            None => None,
         }
     }
 }
 
-fn fill_queue(choices : &HashMap<String, String>, this_queue : &mut VecDeque<String>, this_dict : &Vec<String>, rng : &mut ThreadRng) {
-    while this_queue.len() < this_queue.capacity() { // Revisit this, as capacity may be more than requested, just not less.
+fn fill_queue<'a>(
+    choices: &HashMap<String, HardDictEntry>,
+    this_queue: &mut VecDeque<HardDictEntry>,
+    this_dict: &Vec<DictEntry<'a>>,
+    rng: &mut ThreadRng,
+) {
+    while this_queue.len() < this_queue.capacity() {
+        // Revisit this, as capacity may be more than requested, just not less.
         loop {
+            // TODO There's an infinite loop here if we can't find a non-conflicing matchable.
             let new = this_dict.choose(rng).unwrap();
 
-            if !(
-                    choices.values().into_iter().any(|v| { let min = min(v.len(), new.len()); v[0..min] == (*new).as_str()[0..min] }) ||
-                    this_queue.iter().any(|v| { let min = min(v.len(), new.len()); v[0..min] == (*new).as_str()[0..min] })
-                ) {
-                this_queue.push_back(new.clone());
+            if !(choices.values().into_iter().any(|v| {
+                let min = min(v.matchable().len(), new.matchable().len());
+                v.matchable().as_str()[0..min] == (*new).matchable().as_str()[0..min]
+            }) || this_queue.iter().any(|v| {
+                let min = min(v.matchable().len(), new.matchable().len());
+                v.matchable().as_str()[0..min] == (*new).matchable().as_str()[0..min]
+            })) {
+                this_queue.push_back(new.hard_copy());
                 break;
             }
         }

--- a/src/ui_trait.rs
+++ b/src/ui_trait.rs
@@ -1,6 +1,8 @@
 use crate::backend::Doer;
 
 pub trait UI {
-    fn new(doer : Doer) -> Self where Self: Sized;
+    fn new(doer: Doer) -> Self
+    where
+        Self: Sized;
     fn main_loop(&mut self) -> Result<!, Box<dyn std::error::Error>>;
 }

--- a/src/xdo.rs
+++ b/src/xdo.rs
@@ -1,19 +1,19 @@
-use xdotool::desktop::{activate_window,get_active_window};
 use xdotool::command::options::{KeyboardOption, SearchOption, SyncOption};
-use xdotool::optionvec::OptionVec;
-use xdotool::window::search;
+use xdotool::desktop::{activate_window, get_active_window};
 use xdotool::keyboard::{send_key, send_key_down, send_key_up};
 use xdotool::misc::sleep;
 use xdotool::option_vec;
+use xdotool::optionvec::OptionVec;
+use xdotool::window::search;
 
 pub struct XdoState {
-    current : String,
-    target : String,
-    active : bool,
+    current: String,
+    target: String,
+    active: bool,
 }
 
 impl XdoState {
-    pub fn new(window_name : &str, window_index : usize, active : bool) -> XdoState {
+    pub fn new(window_name: &str, window_index: usize, active: bool) -> XdoState {
         let toutput = search(window_name, option_vec![SearchOption::Name]);
         let mut target = String::from_utf8(toutput.stdout).unwrap();
         target = target.split('\n').collect::<Vec<&str>>()[window_index].to_string();
@@ -30,7 +30,7 @@ impl XdoState {
         }
     }
 
-    pub fn send_key(&self, keys : &str) {
+    pub fn send_key(&self, keys: &str) {
         if self.active {
             self.active_send_key(keys);
         } else {
@@ -38,40 +38,49 @@ impl XdoState {
         }
     }
 
-    pub fn send_key_down(&self, keys : &str) {
+    pub fn send_key_down(&self, keys: &str) {
         if self.active {
             activate_window(&self.target, option_vec![SyncOption::Sync]);
         }
-        send_key_down(keys, option_vec![
-            KeyboardOption::ClearModifiers,
-            KeyboardOption::Window(self.target.clone()),
-        ]);
+        send_key_down(
+            keys,
+            option_vec![
+                KeyboardOption::ClearModifiers,
+                KeyboardOption::Window(self.target.clone()),
+            ],
+        );
         if self.active {
             activate_window(&self.current, OptionVec::new());
         }
     }
 
-    pub fn send_key_up(&self, keys : &str) {
+    pub fn send_key_up(&self, keys: &str) {
         if self.active {
             activate_window(&self.target, option_vec![SyncOption::Sync]);
         }
-        send_key_up(keys, option_vec![
-            KeyboardOption::ClearModifiers,
-            KeyboardOption::Window(self.target.clone()),
-        ]);
+        send_key_up(
+            keys,
+            option_vec![
+                KeyboardOption::ClearModifiers,
+                KeyboardOption::Window(self.target.clone()),
+            ],
+        );
         if self.active {
             activate_window(&self.current, OptionVec::new());
         }
     }
 
-    pub fn inactive_send_key(&self, keys : &str) {
-        send_key(keys, option_vec![
-            KeyboardOption::ClearModifiers,
-            KeyboardOption::Window(self.target.clone()),
-        ]);
+    pub fn inactive_send_key(&self, keys: &str) {
+        send_key(
+            keys,
+            option_vec![
+                KeyboardOption::ClearModifiers,
+                KeyboardOption::Window(self.target.clone()),
+            ],
+        );
     }
 
-    pub fn active_send_key(&self, keys : &str) {
+    pub fn active_send_key(&self, keys: &str) {
         activate_window(&self.target, option_vec![SyncOption::Sync]);
         send_key_down(keys, option_vec![KeyboardOption::ClearModifiers]);
         sleep(0.1);


### PR DESCRIPTION
- Now supports matching against different text to that shown
- Dictionary entries are now dictionaries instead of lists
- Empty values are treated as if the value is the same as the key
- `~` won't work as a value because parsing an empty value results
in `~`.